### PR TITLE
FIX: Suppress :sign place errors

### DIFF
--- a/plugin/cuteErrorMarker.vim
+++ b/plugin/cuteErrorMarker.vim
@@ -121,7 +121,7 @@ fun! MarkErrors( kind ) "{{{
                             \ . ' line=' . error.lnum
                             \ . ' name=' . errClass
                             \ . ' buffer=' . matchedBuf
-                exec toPlace
+                silent! exec toPlace
             endif
         endif
     endfor


### PR DESCRIPTION
I got `E885: Not possible to change sign infohere` when attempting to open `:Glog` with the Fugitive.vim plugin. Just suppress any errors happening during sign placement with `:silent!`
